### PR TITLE
Link to source of US state layout

### DIFF
--- a/r/02.plot.R
+++ b/r/02.plot.R
@@ -372,6 +372,7 @@ rose_nne_light <- dartmouth |>
 
 ggsave(
   file.path(img_dir, "dartmouth_nne_light.svg"),
+  height = 6, width = 8,
   cowplot::ggdraw(segs_nne_light) +
     cowplot::draw_plot(rose_nne_light, .25, 0, .6, .6)
 )

--- a/r/02.plot.R
+++ b/r/02.plot.R
@@ -425,6 +425,8 @@ region <- region_raw |>
     \(x) dplyr::filter(x, num_bins == ngroups_us)
   )
 
+# US state layout slightly modified from 
+# https://erdavis.com/2022/02/09/how-i-made-the-viral-map/
 layout <- c(
   area(1, 1),
   area(1, 11),


### PR DESCRIPTION
These are two slightly different layouts. Neither is perfect.

- [Tweet](https://t.co/YEIamgYb3z): Note Nevada is north of Utah, east of Oregon.
- [Blog post](https://erdavis.com/2022/02/09/how-i-made-the-viral-map/)

What we have is modified slightly from the blogpost: I moved TX and FL one square left.