### PR TITLE
Use NPR US tiles

### DIFF
--- a/r/02.plot.R
+++ b/r/02.plot.R
@@ -425,33 +425,39 @@ region <- region_raw |>
     \(x) dplyr::filter(x, num_bins == ngroups_us)
   )
 
-# US state layout slightly modified from 
-# https://erdavis.com/2022/02/09/how-i-made-the-viral-map/
+# US state layout slightly modified from NPR: move HI and AK in, switch MA and RI.
+# Four corners are preserved. Redditors should be satisfied.
+# https://blog.apps.npr.org/2015/05/11/hex-tile-maps.html
+# This blog post has a good analysis but ignores the US perimeter shape:
+# https://kristw.medium.com/whose-grid-map-is-better-quality-metrics-for-grid-map-layouts-e3d6075d9e80
+
+
 layout <- c(
   area(1, 1),
   area(1, 11),
   area(2, 10, 2, 10), area(2, 11),
-  area(3, 1), area(3, 2), area(3, 3), area(3, 4), area(3, 5),
-  area(3, 7), area(3, 9), area(3, 10), area(3, 11),
+  area(3, 1), area(3, 2), area(3, 3), area(3, 4), area(3, 5), 
+  area(3, 6), area(3, 7), area(3, 8), area(3, 9), area(3, 10), area(3, 11),
   area(4, 1), area(4, 2), area(4, 3), area(4, 4), area(4, 5),
   area(4, 6), area(4, 7), area(4, 8), area(4, 9), area(4, 10),
   area(5, 1), area(5, 2), area(5, 3), area(5, 4), area(5, 5),
   area(5, 6), area(5, 7), area(5, 8), area(5, 9), area(5, 10),
   area(6, 2), area(6, 3), area(6, 4), area(6, 5), area(6, 6),
-  area(6, 7), area(6, 8), area(6, 9), area(6, 10),
-  area(7, 3), area(7, 4), area(7, 5), area(7, 6), area(7, 7), area(7, 8),
-  area(8, 1), area(8, 3), area(8, 9)
+  area(6, 7), area(6, 8), area(6, 9), 
+  area(7, 4), area(7, 5), area(7, 6), area(7, 7), area(7, 8),
+  area(8, 1), area(8, 4), area(8, 9)
 )
 
 layout_title <- c(area(1, 3, 2, 9), layout)
 
 state_names <- c(
   "AK",
-  "ME", "VT", "NH", "WA", "ID", "MT", "ND", "MN", "MI", "NY", "MA", "RI",
-  "OR", "UT", "WY", "SD", "IA", "WI", "OH", "PA", "NJ", "CT",
-  "CA", "NV", "CO", "NE", "IL", "IN", "WV", "VA", "MD", "DE",
-  "AZ", "NM", "KS", "MO", "KY", "TN", "SC", "NC", "DC",
-  "OK", "LA", "AR", "MS", "AL", "GA",
+  "ME", "VT", "NH", "WA", "ID", "MT", "ND", "MN", 
+  "IL", "WI", "MI", "NY", "MA", "RI",
+  "OR", "NV", "WY", "SD", "IA", "IN", "OH", "PA", "NJ", "CT",
+  "CA", "UT", "CO", "NE", "MO", "KY", "WV", "VA", "MD", "DE",
+  "AZ", "NM", "KS", "AR", "TN", "NC", "SC", "DC",
+  "OK", "LA", "MS", "AL", "GA",
   "HI", "TX", "FL"
 )
 

--- a/r/02.plot.R
+++ b/r/02.plot.R
@@ -133,7 +133,7 @@ plot_rose <- function(
   if (!empty_rose) {
     p <- p + geom_col(fill = rose_pink, width = 360 / ngr, color = text_light, linewidth = 0.2)
   } else {
-    p <- p + geom_col(fill = NA)
+    p <- p + geom_col(fill = NA, width = 360 / ngr)
   }
   p <- p +
     annotate(
@@ -150,6 +150,7 @@ plot_rose <- function(
     theme(
       # plot.margin=grid::unit(c(-35,-35, -35, -35), "mm"),
       panel.background = element_rect(fill = aesthetics$circle_fill),
+      axis.text.x = element_text(size = size_x, color = aesthetics$anno_color),
       plot.title = element_blank()
     )
   p
@@ -161,11 +162,12 @@ plot_rose <- function(
 #'
 #' @return ggplot2 object of an empty rose
 rose_empty <- function(ski_area_name, aesthetics) {
-  dat <- data.frame(bin_center = c(0, 360), bin_count = c(1, 1))
+  dat <- dartmouth
+  xmarks <- if (ski_area_name == "FL") c("N", "E", "", "W") else NULL
   plot_rose(
     dat, ski_area_name,
     type = "us", aesthetics = aesthetics,
-    empty_rose = TRUE, labels = NULL
+    empty_rose = TRUE, labels = xmarks
   ) +
     theme(
       plot.background = element_blank(),


### PR DESCRIPTION
Bị ném đá dữ quá nên phải sửa. Instead of the [the layout](https://erdavis.com/2022/02/09/how-i-made-the-viral-map/) by Erin Davis, we're now using [NPR US state tile](https://blog.apps.npr.org/2015/05/11/hex-tile-maps.html) layout with 2 small adjustments: moved HI and AK in and switched RI and MA. This [blog post](https://kristw.medium.com/whose-grid-map-is-better-quality-metrics-for-grid-map-layouts-e3d6075d9e80) has a good analysis on neighbors but essentially ignores the US perimeter shape (what they call "_lookalike_"). To me, NPR has a good balance of "look alike" and "accurate" neighbor states.

These changes attempt to address some comments we received on [r/dataisbeautiful](https://www.reddit.com/r/dataisbeautiful/comments/1i0fmb2/oc_which_way_do_you_ski_orientations_metrics_for/):

> - Does it bother anyone that the four-corners states aren’t contiguous on this graphic? [nickw252](https://www.reddit.com/user/nickw252/)
> - I understand why you did it, but making the chart look square and neat is a ratio, but having Nevada in the four corners spot hurts my brain. Colorado needs Utah! [polkaguy6000](https://www.reddit.com/user/polkaguy6000/)
> - The states not being in their normal alignment is messing with my brain. [TheOnlyVertigo](https://www.reddit.com/user/TheOnlyVertigo/)
> - The choices of positioning some of these states is really weird and makes using the map unintuitive. Oklahoma is south of New Mexico, which is next to Kansas? DC is east of North Carolina, while South Carolina sits between Tennessee and North Carolina? Ohio and Wisconsin are now neighbors? Very weird choices. [shereth78](https://www.reddit.com/user/shereth78/)

Four corners are now preserved. My redditors should be satisfied.
