### PR TITLE
Plot elevation histograms for single-ski areas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 
 /.quarto/
 .Rproj.user
+/docs/
 # pixi environments
 .pixi/*
 !.pixi/config.toml

--- a/openskistats/elevation.py
+++ b/openskistats/elevation.py
@@ -132,6 +132,10 @@ def get_elevation_histogram_data(
     so long segments crossing bin boundaries are accurately distributed rather
     than assigned entirely to a single midpoint bin.
 
+    Segments that fit entirely within a single bin are handled with vectorized
+    Polars expressions; only multi-bin segments fall back to Python row-level
+    splitting.
+
     The default metric is ``distance_vertical_drop`` (skiable vertical), which
     avoids over-representing low-angle runs relative to steep terrain —
     consistent with how combined vertical is used elsewhere in the project.
@@ -146,29 +150,67 @@ def get_elevation_histogram_data(
             }
         )
 
-    _split_schema = pl.List(
-        pl.Struct({"elevation_bin_center": pl.Float64, "binned_value": pl.Float64})
+    bw = bin_width
+    # Compute bin indices for the low/high ends of each segment
+    df = segments.with_columns(
+        _elev_lo=pl.min_horizontal(
+            "elevation", pl.col("elevation") + pl.col("distance_vertical")
+        ),
+        _elev_hi=pl.max_horizontal(
+            "elevation", pl.col("elevation") + pl.col("distance_vertical")
+        ),
+    ).with_columns(
+        _first_idx=(pl.col("_elev_lo") / bw).floor().cast(pl.Int64),
+        _last_idx=(pl.col("_elev_hi") / bw).floor().cast(pl.Int64),
     )
 
-    def _split_segment(row: dict[str, float]) -> list[dict[str, float]]:
-        return _split_segment_across_bins(
-            elevation=row["elevation"],
-            distance_vertical=row["distance_vertical"],
-            value=row["_v"],
-            bin_width=bin_width,
+    single = df.filter(pl.col("_first_idx") == pl.col("_last_idx"))
+    multi = df.filter(pl.col("_first_idx") != pl.col("_last_idx"))
+
+    # Single-bin segments: pure Polars, assign full value to the one bin
+    single_result = single.select(
+        "run_difficulty_condensed",
+        (pl.col("_first_idx") * bw + bw / 2).alias("elevation_bin_center"),
+        pl.col(metric).cast(pl.Float64),
+    )
+
+    # Multi-bin segments: fall back to proportional Python split
+    if multi.is_empty():
+        multi_result = pl.DataFrame(
+            schema={
+                "elevation_bin_center": pl.Float64,
+                "run_difficulty_condensed": pl.String,
+                metric: pl.Float64,
+            }
+        )
+    else:
+        _split_schema = pl.List(
+            pl.Struct({"elevation_bin_center": pl.Float64, "binned_value": pl.Float64})
+        )
+
+        def _split_segment(row: dict[str, float]) -> list[dict[str, float]]:
+            return _split_segment_across_bins(
+                elevation=row["elevation"],
+                distance_vertical=row["distance_vertical"],
+                value=row["_v"],
+                bin_width=bin_width,
+            )
+
+        multi_result = (
+            multi.with_columns(pl.col(metric).alias("_v"))
+            .with_columns(
+                pl.struct("elevation", "distance_vertical", "_v")
+                .map_elements(_split_segment, return_dtype=_split_schema)
+                .alias("_bins")
+            )
+            .select("run_difficulty_condensed", "_bins")
+            .explode("_bins")
+            .unnest("_bins")
+            .rename({"binned_value": metric})
         )
 
     return (
-        segments.with_columns(pl.col(metric).alias("_v"))
-        .with_columns(
-            pl.struct("elevation", "distance_vertical", "_v")
-            .map_elements(_split_segment, return_dtype=_split_schema)
-            .alias("_bins")
-        )
-        .select("run_difficulty_condensed", "_bins")
-        .explode("_bins")
-        .unnest("_bins")
-        .rename({"binned_value": metric})
+        pl.concat([single_result, multi_result])
         .filter(pl.col(metric) > 0)
         .group_by("elevation_bin_center", "run_difficulty_condensed")
         .agg(pl.col(metric).sum())

--- a/openskistats/elevation.py
+++ b/openskistats/elevation.py
@@ -271,106 +271,132 @@ def plot_elevation_histogram(
     y_max: float | None = None,
     x_max: float | None = None,
     metric: ElevationMetric = "distance_vertical_drop",
+    preview: bool = False,
 ) -> Figure:
     """
     Create an elevation distribution histogram for a single ski area.
 
     Horizontal stacked bars with elevation on the y-axis and run length
     on the x-axis, colored by difficulty.
+
+    When *preview* is ``True``, produce a compact mini-histogram with no
+    title, axes labels, grid, stats, or spines — suitable for thumbnail
+    grids.
     """
-    from openskistats.analyze import load_ski_areas_pl
-
-    info: dict[str, Any] = load_ski_areas_pl(
-        ski_area_filters=[pl.col("ski_area_id") == ski_area_id]
-    ).row(0, named=True)
-
     segments = _get_elevation_segments(ski_area_id)
     histogram = get_elevation_histogram_data(
         segments, bin_width=bin_width, metric=metric
     )
 
-    colormap = SkiRunDifficulty.colormap(
-        condense=True, subtle=True, convention=convention
-    )
-    difficulties = SkiRunDifficulty.condensed_values()
-    elevation_centers = histogram["elevation_bin_center"].unique().sort().to_numpy()
-
-    # pivot so each difficulty is a column aligned to elevation bins
-    pivoted = (
-        histogram.pivot(
-            on="run_difficulty_condensed",
-            index="elevation_bin_center",
-            values=metric,
-        )
-        .sort("elevation_bin_center")
-        .fill_null(0)
-    )
-
     fig, ax = plt.subplots(figsize=figsize)
 
-    cumulative = np.zeros(len(elevation_centers), dtype=np.float64)
-    for diff in difficulties:
-        if diff.value not in pivoted.columns:
-            continue
-        values = pivoted[diff.value].to_numpy()
-        if values.sum() == 0:
-            continue
+    if preview:
+        # single-color bars grouped across all difficulties
+        totals = (
+            histogram.group_by("elevation_bin_center")
+            .agg(pl.col(metric).sum())
+            .sort("elevation_bin_center")
+        )
+        elevation_centers = totals["elevation_bin_center"].to_numpy()
         ax.barh(
             y=elevation_centers,
-            width=values,
+            width=totals[metric].to_numpy(),
             height=bin_width,
-            left=cumulative,
-            color=colormap[diff],
+            color="#D4A0A7",
             edgecolor="#292929",
             linewidth=0.4,
-            label=diff.value,
             zorder=2,
         )
-        cumulative += values
-
-    ax.set_ylabel("Elevation (m)", fontsize=10)
-    if metric == "distance_3d":
-        ax.set_xlabel("Skiable Distance (km)", fontsize=10)
-        ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x / 1_000:.1f}"))
     else:
-        ax.set_xlabel("Skiable Vertical (m)", fontsize=10)
-        ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
-    ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+        from openskistats.analyze import load_ski_areas_pl
 
-    ski_area_name = info.get("ski_area_name", "")
-    if ski_area_name:
-        ax.set_title(
-            "\n".join(textwrap.wrap(ski_area_name, width=30)),
-            fontsize=14,
-            fontweight="bold",
-            pad=10,
+        info: dict[str, Any] = load_ski_areas_pl(
+            ski_area_filters=[pl.col("ski_area_id") == ski_area_id]
+        ).row(0, named=True)
+
+        colormap = SkiRunDifficulty.colormap(
+            condense=True, subtle=True, convention=convention
+        )
+        difficulties = SkiRunDifficulty.condensed_values()
+        elevation_centers = histogram["elevation_bin_center"].unique().sort().to_numpy()
+
+        # pivot so each difficulty is a column aligned to elevation bins
+        pivoted = (
+            histogram.pivot(
+                on="run_difficulty_condensed",
+                index="elevation_bin_center",
+                values=metric,
+            )
+            .sort("elevation_bin_center")
+            .fill_null(0)
         )
 
-    # bottom-right: vertical drop, elevation range, and median elevation
-    median_elev = _compute_median_elevation(segments)
-    parts = []
-    if (vd := info.get("vertical_drop")) is not None:
-        parts.append(f"{vd:,.0f}{NARROW_SPACE}m vert drop")
-    if (lo := info.get("min_elevation")) is not None and (
-        hi := info.get("max_elevation")
-    ) is not None:
-        parts.append(f"{lo:,.0f}–{hi:,.0f}{NARROW_SPACE}m")
-    if median_elev is not None:
-        parts.append(f"{median_elev:,.0f}{NARROW_SPACE}m median elev")
-    if parts:
-        ax.text(
-            0.97,
-            0.03,
-            "\n".join(parts),
-            transform=ax.transAxes,
-            fontsize=7,
-            color="#95A5A6",
-            va="bottom",
-            ha="right",
-        )
+        cumulative = np.zeros(len(elevation_centers), dtype=np.float64)
+        for diff in difficulties:
+            if diff.value not in pivoted.columns:
+                continue
+            values = pivoted[diff.value].to_numpy()
+            if values.sum() == 0:
+                continue
+            ax.barh(
+                y=elevation_centers,
+                width=values,
+                height=bin_width,
+                left=cumulative,
+                color=colormap[diff],
+                edgecolor="#292929",
+                linewidth=0.4,
+                label=diff.value,
+                zorder=2,
+            )
+            cumulative += values
 
-    ax.grid(axis="x", alpha=0.3, zorder=0)
-    ax.set_axisbelow(True)
+        ax.set_ylabel("Elevation (m)", fontsize=10)
+        if metric == "distance_3d":
+            ax.set_xlabel("Skiable Distance (km)", fontsize=10)
+            ax.xaxis.set_major_formatter(
+                plt.FuncFormatter(lambda x, _: f"{x / 1_000:.1f}")
+            )
+        else:
+            ax.set_xlabel("Skiable Vertical (m)", fontsize=10)
+            ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+        ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+
+        ski_area_name = info.get("ski_area_name", "")
+        if ski_area_name:
+            ax.set_title(
+                "\n".join(textwrap.wrap(ski_area_name, width=30)),
+                fontsize=14,
+                fontweight="bold",
+                pad=10,
+            )
+
+        # bottom-right: vertical drop, elevation range, and median elevation
+        median_elev = _compute_median_elevation(segments)
+        parts = []
+        if (vd := info.get("vertical_drop")) is not None:
+            parts.append(f"{vd:,.0f}{NARROW_SPACE}m vert drop")
+        if (lo := info.get("min_elevation")) is not None and (
+            hi := info.get("max_elevation")
+        ) is not None:
+            parts.append(f"{lo:,.0f}–{hi:,.0f}{NARROW_SPACE}m")
+        if median_elev is not None:
+            parts.append(f"{median_elev:,.0f}{NARROW_SPACE}m median elev")
+        if parts:
+            ax.text(
+                0.97,
+                0.03,
+                "\n".join(parts),
+                transform=ax.transAxes,
+                fontsize=7,
+                color="#95A5A6",
+                va="bottom",
+                ha="right",
+            )
+
+        ax.grid(axis="x", alpha=0.3, zorder=0)
+        ax.set_axisbelow(True)
+
     ax.set_xlim(left=0, right=x_max)
     # snap y-axis to bar edges so there is no gap above or below;
     # use caller-supplied bounds when provided for cross-area comparison
@@ -379,13 +405,21 @@ def plot_elevation_histogram(
         y_max if y_max is not None else elevation_centers[-1] + bin_width / 2,
     )
 
-    fig.tight_layout()
+    if preview:
+        ax.set_xticks([])
+        ax.set_yticks([])
+        for spine in ("top", "right", "bottom"):
+            ax.spines[spine].set_visible(False)
+        ax.spines["left"].set_linewidth(0.5)
+        fig.tight_layout(pad=0.3)
+    else:
+        fig.tight_layout()
     return fig
 
 
 def plot_elevation_histogram_preview(
     ski_area_id: str,
-    bin_width: float = _DEFAULT_BIN_WIDTH,
+    bin_width: float = 100.0,
     figsize: tuple[float, float] = (1, 1),
     y_min: float | None = None,
     y_max: float | None = None,
@@ -395,64 +429,15 @@ def plot_elevation_histogram_preview(
     """
     Create a compact preview elevation histogram for a single ski area.
 
-    Mini histogram with no title, legend, or axis labels.
-    Matches the preview rose pattern used in the webapp grid view.
+    Thin wrapper around :func:`plot_elevation_histogram` with ``preview=True``.
     """
-    segments = _get_elevation_segments(ski_area_id)
-    histogram = (
-        get_elevation_histogram_data(segments, bin_width=bin_width, metric=metric)
-        .group_by("elevation_bin_center")
-        .agg(pl.col(metric).sum())
-        .sort("elevation_bin_center")
+    return plot_elevation_histogram(
+        ski_area_id,
+        bin_width=bin_width,
+        figsize=figsize,
+        y_min=y_min,
+        y_max=y_max,
+        x_max=x_max,
+        metric=metric,
+        preview=True,
     )
-    elevation_centers = histogram["elevation_bin_center"].to_numpy()
-    totals = histogram[metric].to_numpy()
-
-    fig, ax = plt.subplots(figsize=figsize)
-    ax.barh(
-        y=elevation_centers,
-        width=totals,
-        height=bin_width,
-        color="#D4A0A7",
-        edgecolor="none",
-        zorder=2,
-    )
-    ax.set_xlim(left=0, right=x_max)
-    ax.set_xticks([])
-    ax.set_yticks([])
-    # snap y-axis to bar edges so there is no gap above or below;
-    # use caller-supplied bounds when provided for cross-area comparison
-    ax.set_ylim(
-        y_min if y_min is not None else elevation_centers[0] - bin_width / 2,
-        y_max if y_max is not None else elevation_centers[-1] + bin_width / 2,
-    )
-    # overlay base and peak elevation labels directly on the chart
-    y_lo, y_hi = elevation_centers[0], elevation_centers[-1]
-    label_kwargs = {
-        "fontsize": 7,
-        "fontweight": "bold",
-        "color": "#4a4a4a",
-        "ha": "left",
-        "zorder": 5,
-        "bbox": {"facecolor": "white", "alpha": 0.7, "edgecolor": "none", "pad": 1},
-    }
-    ax.text(
-        0.04,
-        0.02,
-        f"{y_lo:,.0f}{NARROW_SPACE}m",
-        transform=ax.transAxes,
-        va="bottom",
-        **label_kwargs,
-    )
-    ax.text(
-        0.04,
-        0.98,
-        f"{y_hi:,.0f}{NARROW_SPACE}m",
-        transform=ax.transAxes,
-        va="top",
-        **label_kwargs,
-    )
-    for spine in ax.spines.values():
-        spine.set_visible(False)
-    fig.tight_layout(pad=0)
-    return fig

--- a/openskistats/elevation.py
+++ b/openskistats/elevation.py
@@ -6,7 +6,7 @@ run length across elevation bands, colored by difficulty grade.
 """
 
 import textwrap
-from typing import Any
+from typing import Any, Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -22,6 +22,9 @@ from openskistats.utils import (
     pl_condense_run_difficulty,
 )
 
+ElevationMetric = Literal["distance_3d", "distance_vertical_drop"]
+"""Metric for elevation histogram x-axis: 3-D run distance or skiable vertical."""
+
 _DEFAULT_BIN_WIDTH: float = 25.0
 """Default elevation bin width in meters."""
 
@@ -30,11 +33,11 @@ def _get_elevation_segments(ski_area_id: str) -> pl.DataFrame:
     """
     Load run segments for a single ski area with elevation and difficulty data.
 
-    Each segment is assigned to a single elevation bin by its midpoint
-    elevation. This is valid because the vast majority of segments have
-    a vertical span much smaller than the default 25 m bin width:
-    in test data (Whaleback, Storrs Hill), the median vertical span is
-    ~3 m, P95 is ~18 m, and < 3 % of segments exceed 25 m vertically.
+    Returns one row per segment with raw elevation bounds, vertical distance,
+    3-D distance, and vert drop.  Downstream,
+    :func:`get_elevation_histogram_data` splits each segment proportionally
+    across all elevation bins it spans rather than assigning it to a single
+    bin by midpoint.
     """
     from openskistats.analyze import load_runs_pl
 
@@ -50,89 +53,213 @@ def _get_elevation_segments(ski_area_id: str) -> pl.DataFrame:
         .explode("run_coordinates_clean")
         .unnest("run_coordinates_clean")
         .filter(pl.col("segment_hash").is_not_null())
-        .with_columns(
-            # distance_vertical = elevation_lag - elevation, so
-            # midpoint ≈ elevation + distance_vertical / 2
-            elevation_midpoint=pl.col("elevation")
-            + pl.col("distance_vertical").truediv(2),
-        )
         .filter(
-            pl.col("elevation_midpoint").is_not_null(),
+            pl.col("elevation").is_not_null(),
+            pl.col("distance_vertical").is_not_null(),
             pl.col("distance_3d").is_not_null(),
             pl.col("distance_3d") > 0,
         )
         .select(
             "run_difficulty_condensed",
-            "elevation_midpoint",
+            "elevation",
+            "distance_vertical",
             "distance_3d",
+            "distance_vertical_drop",
         )
         .collect()
     )
 
 
+def _split_segment_across_bins(
+    elevation: float,
+    distance_vertical: float,
+    value: float,
+    bin_width: float = _DEFAULT_BIN_WIDTH,
+) -> list[dict[str, float]]:
+    """
+    Split a single segment's metric value proportionally across elevation bins.
+
+    The segment runs from ``elevation`` (upper end, since distance_vertical =
+    elevation_lag - elevation) to ``elevation + distance_vertical``.  Each bin
+    the segment spans receives a fraction of ``value`` equal to the overlap of
+    the segment's vertical extent with that bin divided by the total vertical
+    extent of the segment.
+
+    Flat segments (|distance_vertical| < 1e-6) are assigned entirely to the
+    bin containing ``elevation``.
+
+    Returns a list of ``{"elevation_bin_center": float, "binned_value": float}``
+    dicts, one per bin touched.
+    """
+    span = abs(distance_vertical)
+    if span < 1e-6:
+        bin_lo = np.floor(elevation / bin_width) * bin_width
+        return [
+            {
+                "elevation_bin_center": float(bin_lo + bin_width / 2),
+                "binned_value": float(value),
+            }
+        ]
+    elev_lo = min(elevation, elevation + distance_vertical)
+    elev_hi = max(elevation, elevation + distance_vertical)
+    first_idx = int(np.floor(elev_lo / bin_width))
+    last_idx = int(np.floor(elev_hi / bin_width))
+    results: list[dict[str, float]] = []
+    for i in range(first_idx, last_idx + 1):
+        lo = i * bin_width
+        hi = lo + bin_width
+        overlap = min(elev_hi, hi) - max(elev_lo, lo)
+        if overlap > 0:
+            results.append(
+                {
+                    "elevation_bin_center": float(lo + bin_width / 2),
+                    "binned_value": float(value * overlap / span),
+                }
+            )
+    return results
+
+
 def get_elevation_histogram_data(
     segments: pl.DataFrame,
     bin_width: float = _DEFAULT_BIN_WIDTH,
+    metric: ElevationMetric = "distance_vertical_drop",
 ) -> pl.DataFrame:
     """
-    Bin segments by elevation and aggregate total 3D run length per bin,
+    Bin segments by elevation and aggregate the chosen metric per bin,
     broken down by condensed difficulty.
+
+    Each segment is split proportionally across all elevation bins it spans,
+    so long segments crossing bin boundaries are accurately distributed rather
+    than assigned entirely to a single midpoint bin.
+
+    The default metric is ``distance_vertical_drop`` (skiable vertical), which
+    avoids over-representing low-angle runs relative to steep terrain —
+    consistent with how combined vertical is used elsewhere in the project.
+    Pass ``metric="distance_3d"`` to use 3-D run length instead.
     """
     if segments.is_empty():
         return pl.DataFrame(
             schema={
                 "elevation_bin_center": pl.Float64,
                 "run_difficulty_condensed": pl.String,
-                "distance_3d": pl.Float64,
+                metric: pl.Float64,
             }
         )
 
-    min_elev = segments["elevation_midpoint"].min()
-    max_elev = segments["elevation_midpoint"].max()
-    assert min_elev is not None
-    assert max_elev is not None
-    bin_lower = np.floor(min_elev / bin_width) * bin_width
-    bin_upper = np.ceil(max_elev / bin_width) * bin_width + bin_width
-    breaks = np.arange(bin_lower, bin_upper, bin_width)
+    _split_schema = pl.List(
+        pl.Struct({"elevation_bin_center": pl.Float64, "binned_value": pl.Float64})
+    )
+
+    def _split_segment(row: dict[str, float]) -> list[dict[str, float]]:
+        return _split_segment_across_bins(
+            elevation=row["elevation"],
+            distance_vertical=row["distance_vertical"],
+            value=row["_v"],
+            bin_width=bin_width,
+        )
 
     return (
-        segments.with_columns(
-            elevation_bin_center=pl.col("elevation_midpoint")
-            .cut(breaks=breaks, left_closed=True, include_breaks=True)
-            .struct.field("breakpoint")
-            - bin_width / 2,
+        segments.with_columns(pl.col(metric).alias("_v"))
+        .with_columns(
+            pl.struct("elevation", "distance_vertical", "_v")
+            .map_elements(_split_segment, return_dtype=_split_schema)
+            .alias("_bins")
         )
-        .filter(pl.col("elevation_bin_center").is_not_null())
+        .select("run_difficulty_condensed", "_bins")
+        .explode("_bins")
+        .unnest("_bins")
+        .rename({"binned_value": metric})
+        .filter(pl.col(metric) > 0)
         .group_by("elevation_bin_center", "run_difficulty_condensed")
-        .agg(pl.col("distance_3d").sum())
+        .agg(pl.col(metric).sum())
         .sort("elevation_bin_center", "run_difficulty_condensed")
     )
 
 
 def _compute_median_elevation(segments: pl.DataFrame) -> float | None:
-    """Weighted median elevation: 50 % of total run length above and below."""
+    """Weighted median elevation: 50 % of total 3-D run length above and below."""
     total = segments["distance_3d"].sum()
     if not total or total <= 0:
         return None
-    sorted_segs = segments.sort("elevation_midpoint")
+    sorted_segs = segments.with_columns(
+        elevation_midpoint=pl.col("elevation") + pl.col("distance_vertical") / 2
+    ).sort("elevation_midpoint")
     idx = sorted_segs["distance_3d"].cum_sum().search_sorted(total / 2)
     return float(sorted_segs["elevation_midpoint"][min(idx, len(sorted_segs) - 1)])
 
 
-def _draw_median_elevation_line(ax: plt.Axes, y: float) -> None:
+def get_shared_axis_bounds(
+    ski_area_ids: list[str],
+    bin_width: float = _DEFAULT_BIN_WIDTH,
+    share_y: bool = True,
+    share_x: bool = True,
+    metric: ElevationMetric = "distance_vertical_drop",
+) -> tuple[float | None, float | None, float | None]:
     """
-    Draw a line at the median elevation.
+    Compute shared axis bounds for comparing multiple ski areas.
 
-    TODO: styling TBD — using a simple dotted line for now.
+    Returns ``(y_min, y_max, x_max)`` where:
+
+    - ``y_min`` / ``y_max`` are elevation axis limits snapped to bin
+      boundaries so that bars sit flush across all areas, or ``None`` if
+      ``share_y=False``.
+    - ``x_max`` is the metric axis limit rounded up to a clean boundary
+      (nearest km for ``distance_3d``, nearest 100 m for
+      ``distance_vertical_drop``), or ``None`` if ``share_x=False``.
+
+    Pass all three values directly to :func:`plot_elevation_histogram` or
+    :func:`plot_elevation_histogram_preview` (``None`` values are ignored).
+
+    Parameters
+    ----------
+    share_y:
+        Compute shared elevation (y) axis limits.
+    share_x:
+        Compute shared metric (x) axis limit.
+    metric:
+        Which metric to use for the x-axis; must match the value passed to
+        the plot functions.
     """
-    ax.axhline(
-        y=y,
-        color="#6A0DAD",
-        linewidth=1.0,
-        linestyle=(0, (20, 5)),
-        zorder=4,
-        clip_on=False,
+    elev_mins: list[float] = []
+    elev_maxes: list[float] = []
+    bin_maxes: list[float] = []
+
+    for ski_area_id in ski_area_ids:
+        segments = _get_elevation_segments(ski_area_id)
+        if segments.is_empty():
+            continue
+        if share_y:
+            elev_mins.append(float(segments["elevation"].min()))
+            elev_maxes.append(float(segments["elevation"].max()))
+        if share_x:
+            bin_max = (
+                get_elevation_histogram_data(
+                    segments, bin_width=bin_width, metric=metric
+                )
+                .group_by("elevation_bin_center")
+                .agg(pl.col(metric).sum())[metric]
+                .max()
+            )
+            bin_maxes.append(float(bin_max or 0.0))
+
+    if share_y and not elev_mins:
+        raise ValueError("No elevation data found for the supplied ski_area_ids.")
+    if share_x and not bin_maxes:
+        raise ValueError("No distance data found for the supplied ski_area_ids.")
+
+    y_min = (
+        float(np.floor(min(elev_mins) / bin_width) * bin_width - bin_width / 2)
+        if share_y
+        else None
     )
+    y_max = (
+        float(np.ceil(max(elev_maxes) / bin_width) * bin_width + bin_width / 2)
+        if share_y
+        else None
+    )
+    round_to = 1_000 if metric == "distance_3d" else 100
+    x_max = float(np.ceil(max(bin_maxes) / round_to) * round_to) if share_x else None
+    return y_min, y_max, x_max
 
 
 def plot_elevation_histogram(
@@ -140,6 +267,10 @@ def plot_elevation_histogram(
     bin_width: float = _DEFAULT_BIN_WIDTH,
     convention: RunDifficultyConvention = RunDifficultyConvention.north_america,
     figsize: tuple[float, float] = (4, 4),
+    y_min: float | None = None,
+    y_max: float | None = None,
+    x_max: float | None = None,
+    metric: ElevationMetric = "distance_vertical_drop",
 ) -> Figure:
     """
     Create an elevation distribution histogram for a single ski area.
@@ -154,7 +285,9 @@ def plot_elevation_histogram(
     ).row(0, named=True)
 
     segments = _get_elevation_segments(ski_area_id)
-    histogram = get_elevation_histogram_data(segments, bin_width=bin_width)
+    histogram = get_elevation_histogram_data(
+        segments, bin_width=bin_width, metric=metric
+    )
 
     colormap = SkiRunDifficulty.colormap(
         condense=True, subtle=True, convention=convention
@@ -167,7 +300,7 @@ def plot_elevation_histogram(
         histogram.pivot(
             on="run_difficulty_condensed",
             index="elevation_bin_center",
-            values="distance_3d",
+            values=metric,
         )
         .sort("elevation_bin_center")
         .fill_null(0)
@@ -196,8 +329,12 @@ def plot_elevation_histogram(
         cumulative += values
 
     ax.set_ylabel("Elevation (m)", fontsize=10)
-    ax.set_xlabel("Skiable Distance (km)", fontsize=10)
-    ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x / 1_000:.1f}"))
+    if metric == "distance_3d":
+        ax.set_xlabel("Skiable Distance (km)", fontsize=10)
+        ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x / 1_000:.1f}"))
+    else:
+        ax.set_xlabel("Skiable Vertical (m)", fontsize=10)
+        ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
     ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
 
     ski_area_name = info.get("ski_area_name", "")
@@ -234,15 +371,13 @@ def plot_elevation_histogram(
 
     ax.grid(axis="x", alpha=0.3, zorder=0)
     ax.set_axisbelow(True)
-    ax.set_xlim(left=0)
-    # snap y-axis to bar edges so there is no gap above or below
+    ax.set_xlim(left=0, right=x_max)
+    # snap y-axis to bar edges so there is no gap above or below;
+    # use caller-supplied bounds when provided for cross-area comparison
     ax.set_ylim(
-        elevation_centers[0] - bin_width / 2,
-        elevation_centers[-1] + bin_width / 2,
+        y_min if y_min is not None else elevation_centers[0] - bin_width / 2,
+        y_max if y_max is not None else elevation_centers[-1] + bin_width / 2,
     )
-
-    if median_elev is not None:
-        _draw_median_elevation_line(ax, median_elev)
 
     fig.tight_layout()
     return fig
@@ -252,50 +387,44 @@ def plot_elevation_histogram_preview(
     ski_area_id: str,
     bin_width: float = _DEFAULT_BIN_WIDTH,
     figsize: tuple[float, float] = (1, 1),
+    y_min: float | None = None,
+    y_max: float | None = None,
+    x_max: float | None = None,
+    metric: ElevationMetric = "distance_vertical_drop",
 ) -> Figure:
     """
     Create a compact preview elevation histogram for a single ski area.
 
-    Filled area chart, no title, no legend, no x-axis labels, no median line.
+    Mini histogram with no title, legend, or axis labels.
     Matches the preview rose pattern used in the webapp grid view.
     """
     segments = _get_elevation_segments(ski_area_id)
     histogram = (
-        get_elevation_histogram_data(segments, bin_width=bin_width)
+        get_elevation_histogram_data(segments, bin_width=bin_width, metric=metric)
         .group_by("elevation_bin_center")
-        .agg(pl.col("distance_3d").sum())
+        .agg(pl.col(metric).sum())
         .sort("elevation_bin_center")
     )
     elevation_centers = histogram["elevation_bin_center"].to_numpy()
-    totals = histogram["distance_3d"].to_numpy()
-
-    # pad with zero-width points at bin edges so fill extends to ylim
-    y_padded = np.concatenate(
-        [
-            [elevation_centers[0] - bin_width / 2],
-            elevation_centers,
-            [elevation_centers[-1] + bin_width / 2],
-        ]
-    )
-    x_padded = np.concatenate([[0], totals, [0]])
+    totals = histogram[metric].to_numpy()
 
     fig, ax = plt.subplots(figsize=figsize)
-    ax.fill_betweenx(
-        y=y_padded,
-        x1=0,
-        x2=x_padded,
+    ax.barh(
+        y=elevation_centers,
+        width=totals,
+        height=bin_width,
         color="#D4A0A7",
-        edgecolor="#6b6b6b",
-        linewidth=0.4,
+        edgecolor="none",
         zorder=2,
     )
-    ax.set_xlim(left=0)
+    ax.set_xlim(left=0, right=x_max)
     ax.set_xticks([])
     ax.set_yticks([])
-    # snap y-axis to bar edges so there is no gap above or below
+    # snap y-axis to bar edges so there is no gap above or below;
+    # use caller-supplied bounds when provided for cross-area comparison
     ax.set_ylim(
-        elevation_centers[0] - bin_width / 2,
-        elevation_centers[-1] + bin_width / 2,
+        y_min if y_min is not None else elevation_centers[0] - bin_width / 2,
+        y_max if y_max is not None else elevation_centers[-1] + bin_width / 2,
     )
     # overlay base and peak elevation labels directly on the chart
     y_lo, y_hi = elevation_centers[0], elevation_centers[-1]

--- a/openskistats/elevation.py
+++ b/openskistats/elevation.py
@@ -262,6 +262,105 @@ def get_shared_axis_bounds(
     return y_min, y_max, x_max
 
 
+def _plot_elevation_detail(
+    ax: plt.Axes,
+    ski_area_id: str,
+    segments: pl.DataFrame,
+    histogram: pl.DataFrame,
+    bin_width: float,
+    convention: RunDifficultyConvention,
+    metric: ElevationMetric,
+) -> Any:
+    """Plot the full-detail elevation histogram with stacked difficulty bars."""
+    from openskistats.analyze import load_ski_areas_pl
+
+    info: dict[str, Any] = load_ski_areas_pl(
+        ski_area_filters=[pl.col("ski_area_id") == ski_area_id]
+    ).row(0, named=True)
+
+    colormap = SkiRunDifficulty.colormap(
+        condense=True, subtle=True, convention=convention
+    )
+    difficulties = SkiRunDifficulty.condensed_values()
+    elevation_centers = histogram["elevation_bin_center"].unique().sort().to_numpy()
+
+    # pivot so each difficulty is a column aligned to elevation bins
+    pivoted = (
+        histogram.pivot(
+            on="run_difficulty_condensed",
+            index="elevation_bin_center",
+            values=metric,
+        )
+        .sort("elevation_bin_center")
+        .fill_null(0)
+    )
+
+    cumulative = np.zeros(len(elevation_centers), dtype=np.float64)
+    for diff in difficulties:
+        if diff.value not in pivoted.columns:
+            continue
+        values = pivoted[diff.value].to_numpy()
+        if values.sum() == 0:
+            continue
+        ax.barh(
+            y=elevation_centers,
+            width=values,
+            height=bin_width,
+            left=cumulative,
+            color=colormap[diff],
+            edgecolor="#292929",
+            linewidth=0.4,
+            label=diff.value,
+            zorder=2,
+        )
+        cumulative += values
+
+    ax.set_ylabel("Elevation (m)", fontsize=10)
+    if metric == "distance_3d":
+        ax.set_xlabel("Skiable Distance (km)", fontsize=10)
+        ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x / 1_000:.1f}"))
+    else:
+        ax.set_xlabel("Skiable Vertical (m)", fontsize=10)
+        ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+    ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+
+    ski_area_name = info.get("ski_area_name", "")
+    if ski_area_name:
+        ax.set_title(
+            "\n".join(textwrap.wrap(ski_area_name, width=30)),
+            fontsize=14,
+            fontweight="bold",
+            pad=10,
+        )
+
+    # bottom-right: vertical drop, elevation range, and median elevation
+    median_elev = _compute_median_elevation(segments)
+    parts = []
+    if (vd := info.get("vertical_drop")) is not None:
+        parts.append(f"{vd:,.0f}{NARROW_SPACE}m vert drop")
+    if (lo := info.get("min_elevation")) is not None and (
+        hi := info.get("max_elevation")
+    ) is not None:
+        parts.append(f"{lo:,.0f}–{hi:,.0f}{NARROW_SPACE}m")
+    if median_elev is not None:
+        parts.append(f"{median_elev:,.0f}{NARROW_SPACE}m median elev")
+    if parts:
+        ax.text(
+            0.97,
+            0.03,
+            "\n".join(parts),
+            transform=ax.transAxes,
+            fontsize=7,
+            color="#95A5A6",
+            va="bottom",
+            ha="right",
+        )
+
+    ax.grid(axis="x", alpha=0.3, zorder=0)
+    ax.set_axisbelow(True)
+    return elevation_centers
+
+
 def plot_elevation_histogram(
     ski_area_id: str,
     bin_width: float = _DEFAULT_BIN_WIDTH,
@@ -308,94 +407,9 @@ def plot_elevation_histogram(
             zorder=2,
         )
     else:
-        from openskistats.analyze import load_ski_areas_pl
-
-        info: dict[str, Any] = load_ski_areas_pl(
-            ski_area_filters=[pl.col("ski_area_id") == ski_area_id]
-        ).row(0, named=True)
-
-        colormap = SkiRunDifficulty.colormap(
-            condense=True, subtle=True, convention=convention
+        elevation_centers = _plot_elevation_detail(
+            ax, ski_area_id, segments, histogram, bin_width, convention, metric
         )
-        difficulties = SkiRunDifficulty.condensed_values()
-        elevation_centers = histogram["elevation_bin_center"].unique().sort().to_numpy()
-
-        # pivot so each difficulty is a column aligned to elevation bins
-        pivoted = (
-            histogram.pivot(
-                on="run_difficulty_condensed",
-                index="elevation_bin_center",
-                values=metric,
-            )
-            .sort("elevation_bin_center")
-            .fill_null(0)
-        )
-
-        cumulative = np.zeros(len(elevation_centers), dtype=np.float64)
-        for diff in difficulties:
-            if diff.value not in pivoted.columns:
-                continue
-            values = pivoted[diff.value].to_numpy()
-            if values.sum() == 0:
-                continue
-            ax.barh(
-                y=elevation_centers,
-                width=values,
-                height=bin_width,
-                left=cumulative,
-                color=colormap[diff],
-                edgecolor="#292929",
-                linewidth=0.4,
-                label=diff.value,
-                zorder=2,
-            )
-            cumulative += values
-
-        ax.set_ylabel("Elevation (m)", fontsize=10)
-        if metric == "distance_3d":
-            ax.set_xlabel("Skiable Distance (km)", fontsize=10)
-            ax.xaxis.set_major_formatter(
-                plt.FuncFormatter(lambda x, _: f"{x / 1_000:.1f}")
-            )
-        else:
-            ax.set_xlabel("Skiable Vertical (m)", fontsize=10)
-            ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
-        ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
-
-        ski_area_name = info.get("ski_area_name", "")
-        if ski_area_name:
-            ax.set_title(
-                "\n".join(textwrap.wrap(ski_area_name, width=30)),
-                fontsize=14,
-                fontweight="bold",
-                pad=10,
-            )
-
-        # bottom-right: vertical drop, elevation range, and median elevation
-        median_elev = _compute_median_elevation(segments)
-        parts = []
-        if (vd := info.get("vertical_drop")) is not None:
-            parts.append(f"{vd:,.0f}{NARROW_SPACE}m vert drop")
-        if (lo := info.get("min_elevation")) is not None and (
-            hi := info.get("max_elevation")
-        ) is not None:
-            parts.append(f"{lo:,.0f}–{hi:,.0f}{NARROW_SPACE}m")
-        if median_elev is not None:
-            parts.append(f"{median_elev:,.0f}{NARROW_SPACE}m median elev")
-        if parts:
-            ax.text(
-                0.97,
-                0.03,
-                "\n".join(parts),
-                transform=ax.transAxes,
-                fontsize=7,
-                color="#95A5A6",
-                va="bottom",
-                ha="right",
-            )
-
-        ax.grid(axis="x", alpha=0.3, zorder=0)
-        ax.set_axisbelow(True)
 
     ax.set_xlim(left=0, right=x_max)
     # snap y-axis to bar edges so there is no gap above or below;

--- a/openskistats/elevation.py
+++ b/openskistats/elevation.py
@@ -1,0 +1,329 @@
+"""
+Elevation distribution histograms for ski areas.
+
+Generates horizontal stacked bar charts showing the distribution of
+run length across elevation bands, colored by difficulty grade.
+"""
+
+import textwrap
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import polars as pl
+from matplotlib.figure import Figure
+
+from openskistats.models import (
+    RunDifficultyConvention,
+    SkiRunDifficulty,
+)
+from openskistats.plot import NARROW_SPACE
+from openskistats.utils import (
+    pl_condense_run_difficulty,
+)
+
+_DEFAULT_BIN_WIDTH: float = 25.0
+"""Default elevation bin width in meters."""
+
+
+def _get_elevation_segments(ski_area_id: str) -> pl.DataFrame:
+    """
+    Load run segments for a single ski area with elevation and difficulty data.
+
+    Each segment is assigned to a single elevation bin by its midpoint
+    elevation. This is valid because the vast majority of segments have
+    a vertical span much smaller than the default 25 m bin width:
+    in test data (Whaleback, Storrs Hill), the median vertical span is
+    ~3 m, P95 is ~18 m, and < 3 % of segments exceed 25 m vertically.
+    """
+    from openskistats.analyze import load_runs_pl
+
+    return (
+        load_runs_pl(
+            ski_area_filters=[pl.col("ski_area_id") == ski_area_id],
+        )
+        .with_columns(pl_condense_run_difficulty())
+        .select(
+            "run_difficulty_condensed",
+            "run_coordinates_clean",
+        )
+        .explode("run_coordinates_clean")
+        .unnest("run_coordinates_clean")
+        .filter(pl.col("segment_hash").is_not_null())
+        .with_columns(
+            # distance_vertical = elevation_lag - elevation, so
+            # midpoint ≈ elevation + distance_vertical / 2
+            elevation_midpoint=pl.col("elevation")
+            + pl.col("distance_vertical").truediv(2),
+        )
+        .filter(
+            pl.col("elevation_midpoint").is_not_null(),
+            pl.col("distance_3d").is_not_null(),
+            pl.col("distance_3d") > 0,
+        )
+        .select(
+            "run_difficulty_condensed",
+            "elevation_midpoint",
+            "distance_3d",
+        )
+        .collect()
+    )
+
+
+def get_elevation_histogram_data(
+    segments: pl.DataFrame,
+    bin_width: float = _DEFAULT_BIN_WIDTH,
+) -> pl.DataFrame:
+    """
+    Bin segments by elevation and aggregate total 3D run length per bin,
+    broken down by condensed difficulty.
+    """
+    if segments.is_empty():
+        return pl.DataFrame(
+            schema={
+                "elevation_bin_center": pl.Float64,
+                "run_difficulty_condensed": pl.String,
+                "distance_3d": pl.Float64,
+            }
+        )
+
+    min_elev = segments["elevation_midpoint"].min()
+    max_elev = segments["elevation_midpoint"].max()
+    assert min_elev is not None
+    assert max_elev is not None
+    bin_lower = np.floor(min_elev / bin_width) * bin_width
+    bin_upper = np.ceil(max_elev / bin_width) * bin_width + bin_width
+    breaks = np.arange(bin_lower, bin_upper, bin_width)
+
+    return (
+        segments.with_columns(
+            elevation_bin_center=pl.col("elevation_midpoint")
+            .cut(breaks=breaks, left_closed=True, include_breaks=True)
+            .struct.field("breakpoint")
+            - bin_width / 2,
+        )
+        .filter(pl.col("elevation_bin_center").is_not_null())
+        .group_by("elevation_bin_center", "run_difficulty_condensed")
+        .agg(pl.col("distance_3d").sum())
+        .sort("elevation_bin_center", "run_difficulty_condensed")
+    )
+
+
+def _compute_median_elevation(segments: pl.DataFrame) -> float | None:
+    """Weighted median elevation: 50 % of total run length above and below."""
+    total = segments["distance_3d"].sum()
+    if not total or total <= 0:
+        return None
+    sorted_segs = segments.sort("elevation_midpoint")
+    idx = sorted_segs["distance_3d"].cum_sum().search_sorted(total / 2)
+    return float(sorted_segs["elevation_midpoint"][min(idx, len(sorted_segs) - 1)])
+
+
+def _draw_median_elevation_line(ax: plt.Axes, y: float) -> None:
+    """
+    Draw a line at the median elevation.
+
+    TODO: styling TBD — using a simple dotted line for now.
+    """
+    ax.axhline(
+        y=y,
+        color="#6A0DAD",
+        linewidth=1.0,
+        linestyle=(0, (20, 5)),
+        zorder=4,
+        clip_on=False,
+    )
+
+
+def plot_elevation_histogram(
+    ski_area_id: str,
+    bin_width: float = _DEFAULT_BIN_WIDTH,
+    convention: RunDifficultyConvention = RunDifficultyConvention.north_america,
+    figsize: tuple[float, float] = (4, 4),
+) -> Figure:
+    """
+    Create an elevation distribution histogram for a single ski area.
+
+    Horizontal stacked bars with elevation on the y-axis and run length
+    on the x-axis, colored by difficulty.
+    """
+    from openskistats.analyze import load_ski_areas_pl
+
+    info: dict[str, Any] = load_ski_areas_pl(
+        ski_area_filters=[pl.col("ski_area_id") == ski_area_id]
+    ).row(0, named=True)
+
+    segments = _get_elevation_segments(ski_area_id)
+    histogram = get_elevation_histogram_data(segments, bin_width=bin_width)
+
+    colormap = SkiRunDifficulty.colormap(
+        condense=True, subtle=True, convention=convention
+    )
+    difficulties = SkiRunDifficulty.condensed_values()
+    elevation_centers = histogram["elevation_bin_center"].unique().sort().to_numpy()
+
+    # pivot so each difficulty is a column aligned to elevation bins
+    pivoted = (
+        histogram.pivot(
+            on="run_difficulty_condensed",
+            index="elevation_bin_center",
+            values="distance_3d",
+        )
+        .sort("elevation_bin_center")
+        .fill_null(0)
+    )
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    cumulative = np.zeros(len(elevation_centers), dtype=np.float64)
+    for diff in difficulties:
+        if diff.value not in pivoted.columns:
+            continue
+        values = pivoted[diff.value].to_numpy()
+        if values.sum() == 0:
+            continue
+        ax.barh(
+            y=elevation_centers,
+            width=values,
+            height=bin_width,
+            left=cumulative,
+            color=colormap[diff],
+            edgecolor="#292929",
+            linewidth=0.4,
+            label=diff.value,
+            zorder=2,
+        )
+        cumulative += values
+
+    ax.set_ylabel("Elevation (m)", fontsize=10)
+    ax.set_xlabel("Skiable Distance (km)", fontsize=10)
+    ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x / 1_000:.1f}"))
+    ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+
+    ski_area_name = info.get("ski_area_name", "")
+    if ski_area_name:
+        ax.set_title(
+            "\n".join(textwrap.wrap(ski_area_name, width=30)),
+            fontsize=14,
+            fontweight="bold",
+            pad=10,
+        )
+
+    # bottom-right: vertical drop, elevation range, and median elevation
+    median_elev = _compute_median_elevation(segments)
+    parts = []
+    if (vd := info.get("vertical_drop")) is not None:
+        parts.append(f"{vd:,.0f}{NARROW_SPACE}m vert drop")
+    if (lo := info.get("min_elevation")) is not None and (
+        hi := info.get("max_elevation")
+    ) is not None:
+        parts.append(f"{lo:,.0f}–{hi:,.0f}{NARROW_SPACE}m")
+    if median_elev is not None:
+        parts.append(f"{median_elev:,.0f}{NARROW_SPACE}m median elev")
+    if parts:
+        ax.text(
+            0.97,
+            0.03,
+            "\n".join(parts),
+            transform=ax.transAxes,
+            fontsize=7,
+            color="#95A5A6",
+            va="bottom",
+            ha="right",
+        )
+
+    ax.grid(axis="x", alpha=0.3, zorder=0)
+    ax.set_axisbelow(True)
+    ax.set_xlim(left=0)
+    # snap y-axis to bar edges so there is no gap above or below
+    ax.set_ylim(
+        elevation_centers[0] - bin_width / 2,
+        elevation_centers[-1] + bin_width / 2,
+    )
+
+    if median_elev is not None:
+        _draw_median_elevation_line(ax, median_elev)
+
+    fig.tight_layout()
+    return fig
+
+
+def plot_elevation_histogram_preview(
+    ski_area_id: str,
+    bin_width: float = _DEFAULT_BIN_WIDTH,
+    figsize: tuple[float, float] = (1, 1),
+) -> Figure:
+    """
+    Create a compact preview elevation histogram for a single ski area.
+
+    Filled area chart, no title, no legend, no x-axis labels, no median line.
+    Matches the preview rose pattern used in the webapp grid view.
+    """
+    segments = _get_elevation_segments(ski_area_id)
+    histogram = (
+        get_elevation_histogram_data(segments, bin_width=bin_width)
+        .group_by("elevation_bin_center")
+        .agg(pl.col("distance_3d").sum())
+        .sort("elevation_bin_center")
+    )
+    elevation_centers = histogram["elevation_bin_center"].to_numpy()
+    totals = histogram["distance_3d"].to_numpy()
+
+    # pad with zero-width points at bin edges so fill extends to ylim
+    y_padded = np.concatenate(
+        [
+            [elevation_centers[0] - bin_width / 2],
+            elevation_centers,
+            [elevation_centers[-1] + bin_width / 2],
+        ]
+    )
+    x_padded = np.concatenate([[0], totals, [0]])
+
+    fig, ax = plt.subplots(figsize=figsize)
+    ax.fill_betweenx(
+        y=y_padded,
+        x1=0,
+        x2=x_padded,
+        color="#D4A0A7",
+        edgecolor="#6b6b6b",
+        linewidth=0.4,
+        zorder=2,
+    )
+    ax.set_xlim(left=0)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    # snap y-axis to bar edges so there is no gap above or below
+    ax.set_ylim(
+        elevation_centers[0] - bin_width / 2,
+        elevation_centers[-1] + bin_width / 2,
+    )
+    # overlay base and peak elevation labels directly on the chart
+    y_lo, y_hi = elevation_centers[0], elevation_centers[-1]
+    label_kwargs = {
+        "fontsize": 7,
+        "fontweight": "bold",
+        "color": "#4a4a4a",
+        "ha": "left",
+        "zorder": 5,
+        "bbox": {"facecolor": "white", "alpha": 0.7, "edgecolor": "none", "pad": 1},
+    }
+    ax.text(
+        0.04,
+        0.02,
+        f"{y_lo:,.0f}{NARROW_SPACE}m",
+        transform=ax.transAxes,
+        va="bottom",
+        **label_kwargs,
+    )
+    ax.text(
+        0.04,
+        0.98,
+        f"{y_hi:,.0f}{NARROW_SPACE}m",
+        transform=ax.transAxes,
+        va="top",
+        **label_kwargs,
+    )
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+    fig.tight_layout(pad=0)
+    return fig

--- a/openskistats/tests/test_elevation.py
+++ b/openskistats/tests/test_elevation.py
@@ -6,60 +6,171 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import pytest
 
-from openskistats.analyze import analyze_all_ski_areas_polars
+from openskistats.analyze import analyze_all_ski_areas_polars, load_ski_areas_pl
 from openskistats.elevation import (
     _get_elevation_segments,
+    _split_segment_across_bins,
     get_elevation_histogram_data,
     plot_elevation_histogram,
 )
 
-_WHALEBACK_ID = "28cb013693827a90d778603d8bb6bc0cfd3999c0"
-_STORRS_HILL_ID = "dc24f332f3117625dc09479b5d10cbb31a592be4"
 
-
-def test_get_elevation_segments() -> None:
+@pytest.fixture(scope="module")
+def first_ski_area_id() -> str:
+    """Run analysis pipeline and return an arbitrary ski area ID from the test dataset."""
     analyze_all_ski_areas_polars()
-    segments = _get_elevation_segments(_WHALEBACK_ID)
+    return str(load_ski_areas_pl().row(0, named=True)["ski_area_id"])
+
+
+def test_get_elevation_segments(first_ski_area_id: str) -> None:
+    segments = _get_elevation_segments(first_ski_area_id)
     assert not segments.is_empty()
-    assert segments["elevation_midpoint"].null_count() == 0
+    assert segments["elevation"].null_count() == 0
+    assert segments["distance_vertical"].null_count() == 0
     assert segments["distance_3d"].null_count() == 0
     assert (segments["distance_3d"] > 0).all()
     assert segments["run_difficulty_condensed"].null_count() == 0
-    expected_cols = {
+    assert set(segments.columns) == {
         "run_difficulty_condensed",
-        "elevation_midpoint",
+        "elevation",
+        "distance_vertical",
         "distance_3d",
+        "distance_vertical_drop",
     }
-    assert expected_cols == set(segments.columns)
 
 
-def test_get_elevation_histogram_data() -> None:
-    analyze_all_ski_areas_polars()
-    segments = _get_elevation_segments(_WHALEBACK_ID)
+def test_get_elevation_histogram_data(first_ski_area_id: str) -> None:
+    segments = _get_elevation_segments(first_ski_area_id)
     histogram = get_elevation_histogram_data(segments=segments, bin_width=25.0)
     assert not histogram.is_empty()
-    centers = histogram["elevation_bin_center"].unique().sort()
-    assert centers.len() > 1
-    assert (histogram["distance_3d"] > 0).all()
-    total_from_histogram = histogram["distance_3d"].sum()
-    total_from_segments = segments["distance_3d"].sum()
-    assert total_from_histogram is not None
-    assert total_from_segments is not None
-    assert abs(total_from_histogram - total_from_segments) < 0.01
+    assert histogram["elevation_bin_center"].unique().len() > 1
+    assert (histogram["distance_vertical_drop"] > 0).all()
+    # Conservation: proportional split must preserve total skiable vertical
+    assert (
+        abs(
+            histogram["distance_vertical_drop"].sum()
+            - segments["distance_vertical_drop"].sum()
+        )
+        < 0.01
+    )
 
 
-def test_plot_elevation_histogram() -> None:
-    analyze_all_ski_areas_polars()
-    fig = plot_elevation_histogram(_WHALEBACK_ID)
+def test_get_elevation_histogram_data_distance_3d(first_ski_area_id: str) -> None:
+    """Proportional split must also conserve total 3-D run distance."""
+    segments = _get_elevation_segments(first_ski_area_id)
+    histogram = get_elevation_histogram_data(
+        segments=segments, bin_width=25.0, metric="distance_3d"
+    )
+    assert not histogram.is_empty()
+    assert abs(histogram["distance_3d"].sum() - segments["distance_3d"].sum()) < 0.01
+
+
+def test_get_elevation_histogram_data_narrow_bins(first_ski_area_id: str) -> None:
+    """Exercise histogram with a narrower bin width."""
+    segments = _get_elevation_segments(first_ski_area_id)
+    histogram = get_elevation_histogram_data(segments=segments, bin_width=10.0)
+    assert not histogram.is_empty()
+    assert (histogram["distance_vertical_drop"] > 0).all()
+
+
+def test_plot_elevation_histogram(first_ski_area_id: str) -> None:
+    fig = plot_elevation_histogram(first_ski_area_id)
     assert fig is not None
     plt.close(fig)
 
 
-def test_elevation_histogram_storrs_hill() -> None:
-    """Test with Storrs Hill Ski Area, the second test ski area."""
-    analyze_all_ski_areas_polars()
-    segments = _get_elevation_segments(_STORRS_HILL_ID)
-    histogram = get_elevation_histogram_data(segments=segments, bin_width=10.0)
-    assert not histogram.is_empty()
-    assert (histogram["distance_3d"] > 0).all()
+# ---------------------------------------------------------------------------
+# Unit tests for _split_segment_across_bins
+# These test the core proportional-split logic in isolation, independent of
+# any real ski area data.
+# ---------------------------------------------------------------------------
+
+BW = 25.0  # bin width used throughout unit tests
+
+
+def _bins(results: list[dict[str, float]]) -> dict[float, float]:
+    """Convert split results to {bin_center: value} for easy assertion."""
+    return {r["elevation_bin_center"]: r["binned_value"] for r in results}
+
+
+@pytest.mark.parametrize(
+    "elevation, distance_vertical, value, expected_bins",
+    [
+        pytest.param(
+            210.0,
+            -10.0,
+            100.0,
+            {212.5: 100.0},
+            id="within_single_bin",
+        ),
+        pytest.param(
+            # spans [200, 230]: bin [200,225)=25, bin [225,250)=5, total=30
+            230.0,
+            -30.0,
+            60.0,
+            {212.5: 50.0, 237.5: 10.0},
+            id="crosses_one_boundary",
+        ),
+        pytest.param(
+            # spans [200, 275]: three equal 25m bins
+            275.0,
+            -75.0,
+            90.0,
+            {212.5: 30.0, 237.5: 30.0, 262.5: 30.0},
+            id="spans_three_bins",
+        ),
+        pytest.param(
+            # ascending: elevation=200, dv=+50 => spans [200, 250], two equal bins
+            200.0,
+            50.0,
+            100.0,
+            {212.5: 50.0, 237.5: 50.0},
+            id="ascending_segment",
+        ),
+        pytest.param(
+            210.0,
+            0.0,
+            42.0,
+            {212.5: 42.0},
+            id="flat_segment",
+        ),
+        pytest.param(
+            # upper end sits exactly on boundary 250; must not bleed into [250,275)
+            250.0,
+            -50.0,
+            100.0,
+            {212.5: 50.0, 237.5: 50.0},
+            id="exact_bin_boundary",
+        ),
+    ],
+)
+def test_split_segment_shape(
+    elevation: float,
+    distance_vertical: float,
+    value: float,
+    expected_bins: dict[float, float],
+) -> None:
+    result = _bins(_split_segment_across_bins(elevation, distance_vertical, value, BW))
+    assert set(result.keys()) == set(expected_bins.keys())
+    for center, expected_val in expected_bins.items():
+        assert abs(result[center] - expected_val) < 1e-9
+
+
+@pytest.mark.parametrize(
+    "elevation, distance_vertical, value",
+    [
+        pytest.param(300.0, -73.0, 55.0, id="crosses_several_bins"),
+        pytest.param(100.0, 0.0, 10.0, id="flat"),
+        pytest.param(225.0, -25.0, 25.0, id="exactly_one_bin_width"),
+        pytest.param(412.5, -87.3, 1.0, id="odd_numbers"),
+    ],
+)
+def test_split_segment_conservation(
+    elevation: float, distance_vertical: float, value: float
+) -> None:
+    """Sum of split values must always equal the original value."""
+    result = _split_segment_across_bins(elevation, distance_vertical, value, BW)
+    total = sum(r["binned_value"] for r in result)
+    assert abs(total - value) < 1e-9

--- a/openskistats/tests/test_elevation.py
+++ b/openskistats/tests/test_elevation.py
@@ -1,0 +1,65 @@
+"""
+Tests for elevation distribution histograms.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from openskistats.analyze import analyze_all_ski_areas_polars
+from openskistats.elevation import (
+    _get_elevation_segments,
+    get_elevation_histogram_data,
+    plot_elevation_histogram,
+)
+
+_WHALEBACK_ID = "28cb013693827a90d778603d8bb6bc0cfd3999c0"
+_STORRS_HILL_ID = "dc24f332f3117625dc09479b5d10cbb31a592be4"
+
+
+def test_get_elevation_segments() -> None:
+    analyze_all_ski_areas_polars()
+    segments = _get_elevation_segments(_WHALEBACK_ID)
+    assert not segments.is_empty()
+    assert segments["elevation_midpoint"].null_count() == 0
+    assert segments["distance_3d"].null_count() == 0
+    assert (segments["distance_3d"] > 0).all()
+    assert segments["run_difficulty_condensed"].null_count() == 0
+    expected_cols = {
+        "run_difficulty_condensed",
+        "elevation_midpoint",
+        "distance_3d",
+    }
+    assert expected_cols == set(segments.columns)
+
+
+def test_get_elevation_histogram_data() -> None:
+    analyze_all_ski_areas_polars()
+    segments = _get_elevation_segments(_WHALEBACK_ID)
+    histogram = get_elevation_histogram_data(segments=segments, bin_width=25.0)
+    assert not histogram.is_empty()
+    centers = histogram["elevation_bin_center"].unique().sort()
+    assert centers.len() > 1
+    assert (histogram["distance_3d"] > 0).all()
+    total_from_histogram = histogram["distance_3d"].sum()
+    total_from_segments = segments["distance_3d"].sum()
+    assert total_from_histogram is not None
+    assert total_from_segments is not None
+    assert abs(total_from_histogram - total_from_segments) < 0.01
+
+
+def test_plot_elevation_histogram() -> None:
+    analyze_all_ski_areas_polars()
+    fig = plot_elevation_histogram(_WHALEBACK_ID)
+    assert fig is not None
+    plt.close(fig)
+
+
+def test_elevation_histogram_storrs_hill() -> None:
+    """Test with Storrs Hill Ski Area, the second test ski area."""
+    analyze_all_ski_areas_polars()
+    segments = _get_elevation_segments(_STORRS_HILL_ID)
+    histogram = get_elevation_histogram_data(segments=segments, bin_width=10.0)
+    assert not histogram.is_empty()
+    assert (histogram["distance_3d"] > 0).all()


### PR DESCRIPTION
## Elevation distribution histograms - Component of #72 

Adds two chart types showing how skiable distance is distributed across elevation bands, broken down by difficulty.

### Full histogram

Horizontal stacked bar chart — elevation on the y-axis, 3D distance (km) on the x-axis, bars coloured by condensed difficulty grade. Annotated with vertical drop, elevation range, and weighted median elevation (dotted purple line).

<img width="200" alt="whaleback_elevation_histogram" src="https://github.com/user-attachments/assets/9c2339ed-19d1-4b96-99da-ea4ad65690c3" />
<img width="200" alt="storrs_hill_elevation_histogram" src="https://github.com/user-attachments/assets/09c9bb86-786f-462d-a80c-755dae5f292f" />

### Preview thumbnail

Compact 1×1" version for grid views, matching the mini-rose pattern — aggregates all difficulties into a single filled area curve.

<img width="80" alt="whaleback_elevation_preview" src="https://github.com/user-attachments/assets/e6ca14fe-07b4-43c1-a75e-37b907d9b7d6" />
<img width="80" alt="storrs_hill_elevation_preview" src="https://github.com/user-attachments/assets/b23a992b-8570-4953-9c36-6d7b881e619f" />

---

### Implementation notes

Each run is exploded to its coordinate segments. A segment's elevation is taken as its start elevation plus half its vertical drop (i.e. midpoint), then assigned to a 25 m bin via Polars `cut`. Distance is aggregated per bin per difficulty. This is an approximation — the median vertical span per segment in the test data is ~3 m with P95 ~18 m, so misclassification across bin boundaries is rare.

Median elevation is a weighted median over segments (50% of total 3D distance above/below), not a simple mean.

---

### Open questions

**Preview design** — not fully sold on the area chart for the thumbnail. A micro bar chart would be more consistent with the full view but may be too visually noisy at 1×1". Genuinely open to alternatives here.

**Median line** — experimented with rendering it as a wavy track to suggest a ski run, but it read as noise rather than signal at this scale. Kept it as a plain dotted line for now.

**Binning calculation** — the current approach assigns each segment to a single bin by its midpoint elevation. I have a local change that instead splits segments proportionally across all bins they intersect, which avoids misattributing long segments to a single bin. I have not pushed this yet — want to build consensus on the current version first.
